### PR TITLE
WIP AOS-2415 Feature/fix jenkins tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.g
 
 node {
   withCredentials([file(credentialsId: 'dbh-application.properties', variable: 'FILE')]) {
-    sh 'cat $FILE'
+    sh 'cat $FILE > ~/.spring-boot-devtools.properties'
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 #!/usr/bin/env groovy
 
 def jenkinsfile
-def version = 'v4.1'
-fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git', version) {
-  jenkinsfile = fileLoader.load('templates/leveransepakke')
+def version = 'feature/template-without-executor'
+fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git',version) {
+  jenkinsfile = fileLoader.load('templates/no-executor/leveransepakke')
 }
 
 node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ try {
   def overrides = [piTests: false, disableAllReports: true]
   jenkinsfile.gradle(version, overrides)
 } finally {
-  sh 'rm ~/.spring-boot-devtools.properties'
+  node {
+    sh 'rm ~/.spring-boot-devtools.properties'
+  }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,5 +12,10 @@ node {
   }
 }
 
-def overrides = [piTests: false, disableAllReports: true]
-jenkinsfile.gradle(version, overrides)
+try {
+  def overrides = [piTests: false, disableAllReports: true]
+  jenkinsfile.gradle(version, overrides)
+} finally {
+  sh 'rm ~/.spring-boot-devtools.properties'
+}
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,10 @@ fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.g
   jenkinsfile = fileLoader.load('templates/leveransepakke')
 }
 
-withCredentials([file(credentialsId: 'dbh-application.properties', variable: 'FILE')]) {
-  sh 'cat $FILE'
+node {
+  withCredentials([file(credentialsId: 'dbh-application.properties', variable: 'FILE')]) {
+    sh 'cat $FILE'
+  }
 }
 
 def overrides = [piTests: false, disableAllReports: true]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,9 @@ fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.g
   jenkinsfile = fileLoader.load('templates/leveransepakke')
 }
 
+withCredentials([file(credentialsId: 'dbh-application.properties', variable: 'FILE')]) {
+  sh 'cat $FILE'
+}
+
 def overrides = [piTests: false, disableAllReports: true]
 jenkinsfile.gradle(version, overrides)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 def jenkinsfile
 def version = 'v4.1'
-fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git',version) {
+fileLoader.withGit('https://git.aurora.skead.no/scm/ao/aurora-pipeline-scripts.git', version) {
   jenkinsfile = fileLoader.load('templates/leveransepakke')
 }
 
@@ -10,13 +10,11 @@ node {
   withCredentials([file(credentialsId: 'dbh-application.properties', variable: 'FILE')]) {
     sh 'cat $FILE > ~/.spring-boot-devtools.properties'
   }
-}
 
-try {
-  def overrides = [piTests: false, disableAllReports: true]
-  jenkinsfile.gradle(version, overrides)
-} finally {
-  node {
+  try {
+    def overrides = [piTests: false, disableAllReports: true]
+    jenkinsfile.gradle(version, overrides)
+  } finally {
     sh 'rm ~/.spring-boot-devtools.properties'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,6 @@ dependencies {
   )
 }
 
-test.onlyIf { false }
-
 task wrapper(type: Wrapper) {
   gradleVersion = '4.5.1'
 }


### PR DESCRIPTION
Har opprettet en egen branch i pipeline-scripts. Der har jeg kopiert leveransepakke-template til en undermappe /no-executor og fjernet `node{...}` fra templaten. Den orignale leveransepakke-template refererer til templaten i **no-executor**.

Da kan vi spesifisere `node{...}` i Jenkinsfile og vi har muligheter til å gjøre andre operasjoner på jenkins-slaven før og etter pipeline-scriptet er kjørt.